### PR TITLE
Remove package references from WebApi project file

### DIFF
--- a/src/Genocs.Core.Demo.WebApi/Genocs.Core.Demo.WebApi.csproj
+++ b/src/Genocs.Core.Demo.WebApi/Genocs.Core.Demo.WebApi.csproj
@@ -33,7 +33,6 @@
 
     <ItemGroup>
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.3.4" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="9.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Removed the `Microsoft.AspNetCore.Authentication.Certificate` package reference (v9.0.0) and the `MassTransit.RabbitMQ` package reference (v8.3.4) from `Genocs.Core.Demo.WebApi.csproj`.